### PR TITLE
Corrigindo erros no ano e digitação do rodapé

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
     </main>
     <footer>
         <section>
-        <p>&copy; 2026 Soia Cnnt. Tds s dritos rsedos.</p>
+        <p>&copy; 2026 Sonia Connét. Todos os direitos reservados.</p>
         </section>
         <section id="socialmedia">
             <span>xxxxx</span>


### PR DESCRIPTION
Corrigindo alguns erros
O ano que estava atualmente no site era 2021, e agora foi atualizado para 2026.
Existia alguns erros na digitação do rodapé, e agora esses erros foram corrigidos.

#5 
#6 